### PR TITLE
add option of mapquest api version

### DIFF
--- a/lib/mapquest.rb
+++ b/lib/mapquest.rb
@@ -8,10 +8,11 @@ require "mapquest/services/geocoding"
 
 class MapQuest
 
-  attr_accessor :api_key
+  attr_accessor :api_key, :version
 
-  def initialize(key)
+  def initialize(key, version=1)
     @api_key = key
+    @version = version
   end
 
   # Acess the geocoding API

--- a/lib/mapquest/services/directions.rb
+++ b/lib/mapquest/services/directions.rb
@@ -17,7 +17,7 @@ class MapQuest
         if from && to
           options[:to] = to
           options[:from] = from
-          call_api self, 1, 'route', options
+          call_api self, @mapquest.version, 'route', options
         else
           raise ArgumentError, 'The method must receive the to, and from parameters'
         end

--- a/lib/mapquest/services/geocoding.rb
+++ b/lib/mapquest/services/geocoding.rb
@@ -20,7 +20,7 @@ class MapQuest
       def address(location, options = {})
         raise ArgumentError, 'Method must receive a location (string)' unless location
         options[:location] = location
-        call_api self, 1, 'address', options
+        call_api self, @mapquest.version, 'address', options
       end
 
       # Allows you to search for a location using lat/lng values and returns a response object of the found locations


### PR DESCRIPTION
I add option to set mapquest api version.

If use api v2, 
MapQuest.new(API_KEY, 2)
